### PR TITLE
adding missing dependency with coursecat class

### DIFF
--- a/block_course_overview.php
+++ b/block_course_overview.php
@@ -52,6 +52,7 @@ class block_course_overview extends block_base {
         global $USER, $CFG, $DB, $SESSION;
 
         require_once($CFG->dirroot.'/blocks/course_overview/locallib.php');
+        require_once($CFG->dirroot.'/lib/coursecatlib.php');
         require_once($CFG->dirroot.'/user/profile/lib.php');
 
         if ($this->content !== null) {


### PR DESCRIPTION
With _clean_ theme on moodle 3.3, we have this error message : 
> Exception : Class 'coursecat' not found

It doesn't happen with boost theme.